### PR TITLE
Start with the highest protocol selected.

### DIFF
--- a/lib/Device/Firmata/Protocol.pm
+++ b/lib/Device/Firmata/Protocol.pm
@@ -24,7 +24,7 @@ use Device::Firmata::Base
   FIRMATA_ATTRIBS => {
 	buffer           => [],
 	parse_status     => MIDI_PARSE_NORMAL,
-	protocol_version => 'V_2_01',
+	protocol_version => 'V_2_04', # We are starting with the highest protocol
   };
 
 $MIDI_DATA_SIZES = {


### PR DESCRIPTION
After port openning, some devices do the restart, and sends REPORT_FIRMWARE. We can't to handle this, if we use protocol version 2_01.
