### PR TITLE
or is too low precedence

### DIFF
--- a/lib/Device/Firmata.pm
+++ b/lib/Device/Firmata.pm
@@ -83,7 +83,7 @@ sub listen {
   my $netio = "Device::Firmata::IO::NetIO";
   eval "require $netio";
 
-  return $netio->listen( $ip, $port, $opts ) or die "Could not bind to socket";
+  return $netio->listen( $ip, $port, $opts ) || die "Could not bind to socket";
 }
 
 1;


### PR DESCRIPTION
Line 86 doesn't do what you hope it does. :-)  the low-precedence 'or' means that Perl sees the line as 

```
return( ... ) or die ...
```

which means it'll always return, even if `listen` returns a false value.
