### PR TITLE
added software serial support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Device-Firmata
 
+0.63    2016.03.19 - Jens Beyer
+        supported protocol version detection modified (Protocol)
+        
 0.62    2016.02.22 - Jens Beyer
         added software serial support (Platform, Protocol)
         

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Device-Firmata
 
+0.62    2016.02.22 - Jens Beyer
+        added software serial support (Platform, Protocol)
+        
 0.61    2016.01.09 - Jens Beyer
         added serial pin support (Platform, Protocol, Constants)
         added protocol version query (Platform)

--- a/lib/Device/Firmata.pm
+++ b/lib/Device/Firmata.pm
@@ -15,11 +15,11 @@ Device::Firmata - Perl interface to Firmata for the arduino platform.
 
 =head1 VERSION
 
-Version 0.62
+Version 0.63
 
 =cut
 
-our $VERSION = '0.62';
+our $VERSION = '0.63';
 our $DEBUG = 0;
 
 

--- a/lib/Device/Firmata.pm
+++ b/lib/Device/Firmata.pm
@@ -15,11 +15,11 @@ Device::Firmata - Perl interface to Firmata for the arduino platform.
 
 =head1 VERSION
 
-Version 0.60
+Version 0.62
 
 =cut
 
-our $VERSION = '0.60';
+our $VERSION = '0.62';
 our $DEBUG = 0;
 
 

--- a/lib/Device/Firmata/Platform.pm
+++ b/lib/Device/Firmata/Platform.pm
@@ -867,6 +867,9 @@ sub serial_write {
 
 sub serial_read {
   my ( $self, $port, $numbytes ) = @_;
+  if ($port >= 8) {
+    $self->{io}->data_write($self->{protocol}->packet_serial_listen( $port ));
+  }
   return $self->{io}->data_write($self->{protocol}->packet_serial_read( $port, 0x00, $numbytes ));
 }
 
@@ -876,8 +879,8 @@ sub serial_stopreading {
 }
 
 sub serial_config {
-  my ( $self, $port, $baud ) = @_;
-  return $self->{io}->data_write($self->{protocol}->packet_serial_config( $port, $baud ));
+  my ( $self, $port, $baud, $rxPin, $txPin ) = @_;
+  return $self->{io}->data_write($self->{protocol}->packet_serial_config( $port, $baud, $rxPin, $txPin ));
 }
 
 =head2 poll

--- a/lib/Device/Firmata/Protocol.pm
+++ b/lib/Device/Firmata/Protocol.pm
@@ -99,6 +99,7 @@ our $SERIAL_COMMANDS = {
   SERIAL_WRITE             => 0x20, # write to serial port
   SERIAL_READ              => 0x30, # read request to serial port
   SERIAL_REPLY             => 0x40, # read reply from serial port
+  SERIAL_LISTEN            => 0x70, # start listening on software serial port
 };
 
 our $MODENAMES = {
@@ -1034,18 +1035,44 @@ sub handle_encoder_response {
 # * 3  baud             (bits 0 - 6)
 # * 4  baud             (bits 7 - 13)
 # * 5  baud             (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
-# * 6  rxPin            (0-127) [optional] // only set if platform requires RX pin number @TODO
-# * 7  txPin            (0-127) [optional] // only set if platform requires TX pin number @TODO
+# * 6  rxPin            (0-127) [optional] // only set if platform requires RX pin number
+# * 7  txPin            (0-127) [optional] // only set if platform requires TX pin number
 # * 6|8 END_SYSEX       (0xF7)
 # */
 
 sub packet_serial_config {
-  my ( $self, $port, $baud ) = @_;
+  my ( $self, $port, $baud, $rxPin, $txPin ) = @_;
+  if (defined($rxPin) && defined($txPin)) {
+    return $self->packet_sysex_command( SERIAL_DATA,
+      $SERIAL_COMMANDS->{SERIAL_CONFIG} | $port,
+      $baud & 0x7f,
+      ($baud >> 7) & 0x7f,
+      ($baud >> 14) & 0x7f,
+      $rxPin & 0x7f,
+      $txPin & 0x7f
+    );
+  } else {  
+    return $self->packet_sysex_command( SERIAL_DATA,
+      $SERIAL_COMMANDS->{SERIAL_CONFIG} | $port,
+      $baud & 0x7f,
+      ($baud >> 7) & 0x7f,
+      ($baud >> 14) & 0x7f
+    );
+  }
+}
+
+#/* serial listen
+# * -------------------------------
+# * 0  START_SYSEX      (0xF0)
+# * 1  SERIAL_DATA      (0x60)  // command byte
+# * 2  SERIAL_LISTEN    (0x70)  // OR with port to switch to (0x79 = switch to SW_SERIAL1)
+# * 3  END_SYSEX        (0xF7)
+# */
+
+sub packet_serial_listen {
+  my ( $self, $port ) = @_;
   return $self->packet_sysex_command( SERIAL_DATA,
-    $SERIAL_COMMANDS->{SERIAL_CONFIG} | $port,
-    $baud & 0x7f,
-    ($baud >> 7) & 0x7f,
-    ($baud >> 14) & 0x7f
+    $SERIAL_COMMANDS->{SERIAL_LISTEN} | $port
   );
 }
 

--- a/lib/Device/Firmata/Protocol.pm
+++ b/lib/Device/Firmata/Protocol.pm
@@ -436,7 +436,11 @@ sub packet_query_version {
 }
 
 sub handle_query_version_response {
-
+  my ( $self, $data ) = @_;
+  return {
+      major_version => shift @$data,
+      minor_version => shift @$data,
+    };
 }
 
 sub handle_string_data {
@@ -1288,13 +1292,13 @@ Search list of implemented protocols for identical or next lower version.
 
 sub get_max_supported_protocol_version {
   my ( $self, $deviceProtcolVersion ) = @_;
-  return "" unless (defined($deviceProtcolVersion));
-  return $deviceProtcolVersion if (defined($COMMANDS->{$deviceProtcolVersion}));
+  return "V_2_01" unless (defined($deviceProtcolVersion));                       # min. supported protocol version if undefined
+  return $deviceProtcolVersion if (defined($COMMANDS->{$deviceProtcolVersion})); # requested version if known
   
   my $maxSupportedProtocolVersion = undef;
   foreach my $protocolVersion (sort keys %{$COMMANDS}) {
     if ($protocolVersion lt $deviceProtcolVersion) {
-      $maxSupportedProtocolVersion = $protocolVersion;
+      $maxSupportedProtocolVersion = $protocolVersion;                           # nearest lower version if not known
     }
   }
   


### PR DESCRIPTION
This pull request replaces pull request #25 to separate version 0.63 from follow up commits.

- rx and tx pin numbers for software serial ports are sent to Firmata
  with serial config
- if the serial port is 8 or higher a serial listen will be sent to
  Firmata before reading to open the software serial port so that there is
  no difference for the application between hardware and software serial
  ports when using read
