### PR TITLE
Add missing sub SerialIO::close()

### DIFF
--- a/lib/Device/Firmata/IO/SerialIO.pm
+++ b/lib/Device/Firmata/IO/SerialIO.pm
@@ -40,6 +40,11 @@ sub open {
   return $self;
 }
 
+sub close {
+  my ( $self ) = @_;
+  $self->{handle}->close();
+}
+
 =head2 attach ( serialPort )
 
 Assign a L<Device::SerialPort> (or L<Win32::SerialPort>) as IO port and return a L<Device::Firmata::IO::SerialIO> object. Typically used internally by the C<open()> method.

--- a/lib/Device/Firmata/IO/SerialIO.pm
+++ b/lib/Device/Firmata/IO/SerialIO.pm
@@ -40,10 +40,6 @@ sub open {
   return $self;
 }
 
-sub close {
-  my ( $self ) = @_;
-  $self->{handle}->close();
-}
 
 =head2 attach ( serialPort )
 
@@ -57,6 +53,7 @@ sub attach {
   $self->{handle} = $serial_obj;
   return $self;
 }
+
 
 =head2 data_write
 
@@ -85,6 +82,23 @@ sub data_read {
   print "<".join(",",map{sprintf"%02x",ord$_}split//,$string)."\n" if ( $Device::Firmata::DEBUG and $string );
   return $string;
 }
+
+
+=head2 close
+
+Close serial connection to Firmata device.
+
+=cut
+
+sub close($) {
+# --------------------------------------------------
+  my ( $self ) = @_;
+  if ($self->{handle}) {
+    $self->{handle}->close();
+    delete $self->{handle};
+  }
+}
+
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
[Device::Firmata::Platform->close()](https://github.com/ntruchsess/perl-firmata/blob/f41b68101cdbadd177441ac763f825b9b0a5be30/lib/Device/Firmata/Platform.pm#L107) is calling `close()` on the IO device being a `Device::Firmata::IO::SerialIO` when obtained from [Firmata](https://github.com/ntruchsess/perl-firmata/blob/f41b68101cdbadd177441ac763f825b9b0a5be30/lib/Device/Firmata.pm#L71), but `SerialIO` does not offer this sub.