### PR TITLE
remove unneeded call to SUPER::import

### DIFF
--- a/lib/Device/Firmata/Base.pm
+++ b/lib/Device/Firmata/Base.pm
@@ -58,8 +58,6 @@ sub import {
          __PACKAGE__;
       *{$pkg.'::ISA'} = \@ISA;
     }
-    use strict;
-    $self->SUPER::import( @_ );
   }
 }
 


### PR DESCRIPTION
Device::Firmata::Base has no parent class, so there is no point to calling SUPER::import. This ends up calling UNIVERSAL::import if it exists, and would be a noop. Future perl versions will make it an error to pass arguments to an undefined import method.

Fixes #33 and https://rt.cpan.org/Ticket/Display.html?id=172382